### PR TITLE
Allow using as an instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - CC_TEST_REPORTER_ID=9f58300ca67e8364774e98baa47b6e2dd7ad68a391c3650649081db159c04915
 
 rvm:
-  - "2.2.0"
+  - "2.3.0"
   - "2.5.0"
 
 before_install:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,10 @@
 source "https://rubygems.org"
 
+gem 'byebug'
+gem 'rspec'
+gem 'rspec_fixtures'
+gem 'runfile'
+gem 'runfile-tasks'
+gem 'simplecov'
+
 gemspec

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Features
 
 - [Aggressively minimalistic][1], no dependencies, no monkey-patching, no magic.
 - Settings are accessible through a globally available class.
+- Can be used either as a singleton class or as an instance.
 - Load and merge one or more YAML files or hashes.
 - Settings objects are standard ruby hashes, arrays and basic types.
 - Ability to update settings at runtime.
@@ -43,13 +44,15 @@ Nonfeatures
 --------------------------------------------------
 
 - No dot notation access to nested values - Use `Settings.server['host']` 
-  instead of `Settings.server.host` - to avoid having to monkey-patch hashes.
+  instead of `Settings.server.host`.
 - No special generators for Rails. 
   [Usage with rails is still trivial](#using-with-rails).
 
 
 Usage
 --------------------------------------------------
+
+### Using as a singleton class
 
 ```ruby
 require 'sting'
@@ -61,6 +64,11 @@ Settings = Sting
 # '.yaml', we will add '.yml' to it.
 Settings << 'one'
 Settings << 'two.yml'
+
+# Adding additional files can also be done with `#push`. These two are the 
+# same.
+Settings << 'one'
+Settings.push 'one'
 
 # Merge with another options hash
 Settings << { port: 3000, host: 'localhost' }
@@ -90,6 +98,23 @@ Settings.port = 3000
 
 # Reset (erase) all values
 Settings.reset!
+```
+
+### Using as an instance
+
+All the above operations are also available to instances of Sting.
+
+```ruby
+require 'sting'
+
+# Create an instance.
+config = Sting.new
+
+# Or, create an instance, and provide the first source file to it.
+config = Sting.new 'settings'
+
+# Load additional YAML files. 
+config << 'local_settings'
 ```
 
 
@@ -122,4 +147,4 @@ Create four config files:
 - config/settings/**test**.yml
 
 
-[1]: https://github.com/DannyBen/sting/blob/master/lib/sting.rb
+[1]: https://github.com/DannyBen/sting/blob/master/lib/sting/sting_operations.rb

--- a/lib/sting.rb
+++ b/lib/sting.rb
@@ -1,65 +1,11 @@
 require 'yaml'
 require 'erb'
+require 'sting/sting_operations'
 
 class Sting
+  include StingOperations
+
   class << self
-    def <<(source)
-      if source.is_a? Hash
-        content = source.collect{ |k,v| [k.to_s, v] }.to_h
-      else
-        source = "#{source}.yml" unless source =~ /\.ya?ml$/
-        content = File.read source
-        content = YAML.load(ERB.new(content).result)
-      end
-      settings.merge! content if content
-    end
-
-    def [](key)
-      settings[key.to_s]
-    end
-
-    def method_missing(name, *args, &blk)
-      name = name.to_s
-      return settings[name] if has_key? name
-
-      suffix = nil
-
-      if name.end_with? *['=', '!', '?']
-        suffix = name[-1]
-        name = name[0..-2]
-      end
-
-      case suffix
-      when "="
-        settings[name] = args.first
-
-      when "?"
-        !!settings[name]
-
-      when "!"
-        if has_key? name
-          return settings[name]
-        else
-          raise ArgumentError, "Key '#{name}' does not exist"
-        end
-
-      else
-        nil
-
-      end
-
-    end
-
-    def settings
-      @settings ||= {}
-    end
-
-    def reset!
-      @settings = nil
-    end
-
-    def has_key?(key)
-      settings.has_key? key.to_s
-    end
+    include StingOperations
   end
 end

--- a/lib/sting/sting_operations.rb
+++ b/lib/sting/sting_operations.rb
@@ -1,0 +1,70 @@
+require 'yaml'
+require 'erb'
+
+class Sting
+  module StingOperations
+    def initialize(source = nil)
+      self << source if source
+    end
+
+    def <<(source)
+      if source.is_a? Hash
+        content = source.collect{ |k,v| [k.to_s, v] }.to_h
+      else
+        source = "#{source}.yml" unless source =~ /\.ya?ml$/
+        content = File.read source
+        content = YAML.load(ERB.new(content).result)
+      end
+      settings.merge! content if content
+    end
+    alias_method :push, :<<
+
+    def [](key)
+      settings[key.to_s]
+    end
+
+    def method_missing(name, *args, &blk)
+      name = name.to_s
+      return settings[name] if has_key? name
+
+      suffix = nil
+
+      if name.end_with? *['=', '!', '?']
+        suffix = name[-1]
+        name = name[0..-2]
+      end
+
+      case suffix
+      when "="
+        settings[name] = args.first
+
+      when "?"
+        !!settings[name]
+
+      when "!"
+        if has_key? name
+          return settings[name]
+        else
+          raise ArgumentError, "Key '#{name}' does not exist"
+        end
+
+      else
+        nil
+
+      end
+
+    end
+
+    def settings
+      @settings ||= {}
+    end
+
+    def reset!
+      @settings = nil
+    end
+
+    def has_key?(key)
+      settings.has_key? key.to_s
+    end
+  end
+end

--- a/spec/sting/sting_eigenclass_spec.rb
+++ b/spec/sting/sting_eigenclass_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe Sting do
+  subject { described_class }
+
+  it "behaves as a Sting instance" do
+    instance_methods = subject.new.methods - Object.methods
+    class_methods    = subject.methods - Object.methods
+
+    expect(instance_methods).to eq class_methods
+  end
+end

--- a/spec/sting/sting_spec.rb
+++ b/spec/sting/sting_spec.rb
@@ -1,12 +1,29 @@
 require 'spec_helper'
 
 describe Sting do
-  subject { described_class }
-
   let(:file1) { 'spec/fixtures/one' }
   let(:file2) { 'spec/fixtures/two' }
 
   before { subject.reset!; subject << file1 }
+
+  describe '#initialize' do
+    context "with a source argument" do
+      subject { described_class.new file1 }
+
+      it "adds the source" do
+        expect(subject.some_key).to eq 'some_value'
+      end
+    end
+
+    context "without a source argument" do
+      subject { described_class.new }
+      before { subject.reset! }
+
+      it "does not error" do
+        expect(subject.settings).to eq({})
+      end
+    end
+  end
 
   describe '<<' do
     context "with a string argument" do

--- a/sting.gemspec
+++ b/sting.gemspec
@@ -15,11 +15,4 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/dannyben/sting'
   s.license     = 'MIT'
   s.required_ruby_version = ">= 2.2.0"
-
-  s.add_development_dependency 'byebug', '~> 10.0'
-  s.add_development_dependency 'rspec', '~> 3.6'
-  s.add_development_dependency 'rspec_fixtures', '~> 0.3'
-  s.add_development_dependency 'runfile', '~> 0.10'
-  s.add_development_dependency 'runfile-tasks', '~> 0.4'
-  s.add_development_dependency 'simplecov', '~> 0.15'
 end


### PR DESCRIPTION
- Allow using `config = Sting.new` in addition to the singleton use case.
- Allow using `Settings.push 'file'` in addition to `Settings << 'file'`.
- Tidy up gemspec by moving dev dependencies into the `Gemfile`.
- Drop support for Ruby < 2.3 (just because bundler dropped support, otherwise, it should work).
