### PR TITLE
Implement ExtendedYAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-/tmp
-/spec/tmp
-/coverage
-/dev
-/gems
-/Gemfile.lock
 *.gem
+/coverage
+/debug.rb
+/dev
+/Gemfile.lock
+/gems
+/spec/tmp
+/tmp

--- a/README.md
+++ b/README.md
@@ -19,23 +19,16 @@ $ gem install sting
 ```
 
 
-Why was this made?
---------------------------------------------------
-
-Sting was made to replace the Rails Config gem, which has an unreasonable 
-amount of dependencies (i.e. the dry-validation gem, its children and 
-grandchildren...).
-
-
 Features
 --------------------------------------------------
 
-- [Aggressively minimalistic][1], no dependencies, no monkey-patching, no magic.
+- [Aggressively minimalistic][1].
 - Settings are accessible through a globally available class.
 - Can be used either as a singleton class or as an instance.
 - Load and merge one or more YAML files or hashes.
 - Settings objects are standard ruby hashes, arrays and basic types.
 - Ability to update settings at runtime.
+- [Ability to extend](#extending-yaml-files) (import) other YAML files.
 - ERB code in the YAML files will be evaluated.
 
 
@@ -121,6 +114,22 @@ config << 'local_settings'
 ```
 
 
+### Extending YAML files
+
+Sting uses [ExtendedYAML], which means you can use the `extends` key to load
+one ormore YAML files into your loaded configuration files:
+
+```yaml
+# Extend a single file (extension is optional)
+extends: some-other-file.yml
+
+# Extend multiple files
+extends:
+- some-file
+- another-file
+```
+
+
 Using with Rails
 --------------------------------------------------
 
@@ -151,3 +160,4 @@ Create four config files:
 
 
 [1]: https://github.com/DannyBen/sting/blob/master/lib/sting/sting_operations.rb
+[2]: https://github.com/DannyBen/extended_yaml

--- a/Runfile
+++ b/Runfile
@@ -8,3 +8,5 @@ version Sting::VERSION
 
 RunfileTasks::RubyGems.all 'sting'
 RunfileTasks::Testing.rspec
+
+require_relative 'debug' if File.exist? 'debug.rb'

--- a/lib/sting/sting_operations.rb
+++ b/lib/sting/sting_operations.rb
@@ -1,5 +1,4 @@
-require 'yaml'
-require 'erb'
+require 'extended_yaml'
 
 class Sting
   module StingOperations
@@ -12,8 +11,7 @@ class Sting
         content = source.collect{ |k,v| [k.to_s, v] }.to_h
       else
         source = "#{source}.yml" unless source =~ /\.ya?ml$/
-        content = File.read source
-        content = YAML.load(ERB.new(content).result)
+        content = ExtendedYAML.load source
       end
       settings.merge! content if content
     end
@@ -58,6 +56,7 @@ class Sting
     def settings
       @settings ||= {}
     end
+    alias to_h settings
 
     def reset!
       @settings = nil

--- a/spec/approvals/extends
+++ b/spec/approvals/extends
@@ -1,0 +1,13 @@
+--- !ruby/object:Sting
+settings:
+  grand_parent: true
+  settings:
+    grandparent: true
+    parent: true
+    child: true
+  array:
+  - grandparent
+  - parent
+  - child
+  parent: true
+  child: true

--- a/spec/fixtures/extends/child.yml
+++ b/spec/fixtures/extends/child.yml
@@ -1,0 +1,9 @@
+extends: parent
+
+child: true
+
+settings:
+  child: true
+
+array:
+  - child

--- a/spec/fixtures/extends/grandparent.yml
+++ b/spec/fixtures/extends/grandparent.yml
@@ -1,0 +1,7 @@
+grand_parent: true
+
+settings:
+  grandparent: true
+
+array:
+  - grandparent

--- a/spec/fixtures/extends/parent.yml
+++ b/spec/fixtures/extends/parent.yml
@@ -1,0 +1,9 @@
+extends: grandparent
+
+parent: true
+
+settings:
+  parent: true
+
+array:
+  - parent

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,3 +4,7 @@ SimpleCov.start
 require 'rubygems'
 require 'bundler'
 Bundler.require :default, :development
+
+RSpec.configure do |c|
+  c.fixtures_path = 'spec/approvals'
+end

--- a/spec/sting/sting_spec.rb
+++ b/spec/sting/sting_spec.rb
@@ -5,19 +5,16 @@ describe Sting do
   let(:file2) { 'spec/fixtures/two' }
   let(:file3) { 'spec/fixtures/three' }
 
-  before { subject.reset!; subject << file1 }
+  subject { described_class.new file1 }
 
   describe '#initialize' do
     context "with a source argument" do
-      subject { described_class.new file1 }
-
       it "adds the source" do
         expect(subject.some_key).to eq 'some_value'
       end
     end
 
     context "without a source argument" do
-      subject { described_class.new }
       before { subject.reset! }
 
       it "does not error" do
@@ -98,6 +95,18 @@ describe Sting do
     end
   end
 
+  describe 'settings' do
+    it "returns theh entire settings hash" do
+      expect(subject.settings).to eq({"filename"=>"one", "some_key"=>"some_value"})
+    end
+  end
+
+  describe 'to_h' do
+    it "returns theh entire settings hash" do
+      expect(subject.to_h).to eq({"filename"=>"one", "some_key"=>"some_value"})
+    end
+  end
+
   describe 'method_missing' do
     it "returns a value" do
       expect(subject.filename).to eq 'one'
@@ -136,6 +145,14 @@ describe Sting do
       it "raises ArgumentError" do
         expect{ subject.nokey! }.to raise_error(ArgumentError)
       end
+    end
+  end
+
+  context "when using ExtendedYAML#extends" do
+    subject { described_class.new 'spec/fixtures/extends/child.yml' }
+
+    it "extends the other files" do
+      expect(subject.to_yaml).to match_fixture('extends')
     end
   end
 end

--- a/sting.gemspec
+++ b/sting.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version = ">= 2.2.0"
 
-  s.add_runtime_dependency "extended_yaml", '~> 0.1'
+  s.add_runtime_dependency "extended_yaml", '~> 0.2'
 end

--- a/sting.gemspec
+++ b/sting.gemspec
@@ -15,4 +15,6 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/dannyben/sting'
   s.license     = 'MIT'
   s.required_ruby_version = ">= 2.2.0"
+
+  s.add_runtime_dependency "extended_yaml", '~> 0.1'
 end


### PR DESCRIPTION
Add `ExtendedYAML` so that all configuration files use by Sting, can use the `extends` key to import additional files.

Closes #10